### PR TITLE
Draft: reference hotglue netsuite sdk version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     classifiers=['Programming Language :: Python :: 3 :: Only'],
     py_modules=['tap_netsuite'],
     install_requires=[
-        'netsuitesdk==2.7.4', # USING THE HOTGLUE VERSION
+        'git+https://github.com/hotgluexyz/netsuite-sdk-py.git@2.7.4', # USING THE HOTGLUE VERSION
         'requests==2.21.0',
         'singer-python==5.3.1',
         'xmltodict==0.11.0',


### PR DESCRIPTION
Following a conversation in slack, looks like this reference should point to hotglue netsuite sdk version.